### PR TITLE
Fix production builds.

### DIFF
--- a/app/services/translation-map.js
+++ b/app/services/translation-map.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 
-
-let __TRANSLATION_MAP__ = {};
-export default Ember.Service.extend({ map: __TRANSLATION_MAP__ });
+let map = {
+  __TRANSLATION_MAP__: {}
+};
+export default Ember.Service.extend({ map: map.__TRANSLATION_MAP__ });

--- a/lib/translation-map-rewrite.js
+++ b/lib/translation-map-rewrite.js
@@ -30,5 +30,6 @@ TranslationMapRewrite.prototype.processAndCacheFile = function () {
 };
 
 TranslationMapRewrite.prototype.processString = function(string, relativePath) {
-  return string.replace('__TRANSLATION_MAP__ = {}', '__TRANSLATION_MAP__= ' + JSON.stringify(this.assetMap));
+  let pattern = /__TRANSLATION_MAP__:\s*\{\}/g
+  return string.replace(pattern, '__TRANSLATION_MAP__:' + JSON.stringify(this.assetMap));
 };


### PR DESCRIPTION
Uglify runs _before_ this filter does. This results in the the naive string replacements failing as the module level variable has been replaced. By using a dictionary and regexp we can avoid some of the pitfalls that simple string replacements have.
